### PR TITLE
Updating AKS SKU

### DIFF
--- a/src/infra/bicep/resources/containers.bicep
+++ b/src/infra/bicep/resources/containers.bicep
@@ -101,7 +101,7 @@ resource aks 'Microsoft.ContainerService/managedClusters@2024-03-02-preview' = {
         enableAutoScaling: aksAutoScaling
         minCount: 1 // minimum node count
         maxCount: 3 // maximum node count
-        vmSize: 'standard_d2s_v4'
+        vmSize: 'standard_b2s'
         osType: 'Linux'
         mode: 'System'
         availabilityZones: zoneRedundant ? ['1', '2', '3'] : []


### PR DESCRIPTION
Updating AKS SKU to "standard_b2s"
Reason: Compute instances with ARM architecture causes runtime issues with older DOTNET versions
File: src\infra\bicep\resources\containers.bicep